### PR TITLE
Fix picture URL

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,5 +1,5 @@
 
-<img alt="mythic" align="left" src="./profile/mythic.svg" width="350" style="margin-right: 20px">
+<img alt="mythic" align="left" src="./mythic.svg" width="350" style="margin-right: 20px">
 
 <h3> Mythic Agents Organization</h3>
 


### PR DESCRIPTION
The link for the Mythic picture is pointing to the wrong path. This fixes the picture on the [MythicAgents](https://github.com/MythicAgents) org page README